### PR TITLE
fix(typo-protocol): ProteinProtocol::gmx_bin<~s~>

### DIFF
--- a/gromacs_copilot/protocols/protein.py
+++ b/gromacs_copilot/protocols/protein.py
@@ -589,7 +589,7 @@ class ProteinProtocol(BaseProtocol):
         # Create analysis directory if it doesn't exist
         mkdir_result = self.run_shell_command("mkdir -p analysis")
         
-        cmd = f"echo 'Protein' | {self.gmx_bins} gyrate -s md.tpr -f md.xtc -o analysis/gyrate.xvg"
+        cmd = f"echo 'Protein' | {self.gmx_bin} gyrate -s md.tpr -f md.xtc -o analysis/gyrate.xvg"
         result = self.run_shell_command(cmd)
         
         if not result["success"]:


### PR DESCRIPTION
fix attribute error raised from a typo maybe.

log before this fix:
```text
🔧 TOOL    │ Executing: analyze_gyration
ℹ️  INFO    │ Running command: mkdir -p analysis
$ mkdir -p analysis
✓  SUCCESS │ Command succeeded with no output
✗  ERROR   │ Error running MD LLM agent: 'ProteinProtocol' object has no attribute 'gmx_bins'
┌──────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Error running MD LLM agent: 'ProteinProtocol' object has no attribute 'gmx_bins'                     │
└──────────────────────────────────────────────────────────────────────────────────────────────────────┘
```